### PR TITLE
propagate translator exceptions (see for_pnorman branch)

### DIFF
--- a/ogr2osm.py
+++ b/ogr2osm.py
@@ -293,7 +293,7 @@ class Relation(Geometry):
         Geometry.__init__(self)
         self.members = []
     def replacejwithi(self, i, j):
-        self.members = [i if x == j else x for x in self.members]
+        self.members = [(i, x[1]) if x[0] == j else x for x in self.members]
         j.removeparent(self)
         i.addparent(self)
 


### PR DESCRIPTION
Hello Paul,

I've been working on a translator and found that exceptions from my translator functions were not appearing.  I came up with a solution and would be grateful if you'd except it into the mainline.  I also fixed a failing test.  It seems that the sp_usinas test data attributes are in Latin-1 not UTF-8.  But if the test passes on your machine, maybe I'm wrong about this.

Ciao,
Brian
