### PR TITLE
add a LICENSE file containing the MIT license text, as is necessary

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2012-2013 Paul Norman <penorman@mac.com>, Sebastiaan Couwenberg 
+<sebastic@xs4all.nl>, The University of Vermont <andrew.guertin@uvm.edu>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/geom.py
+++ b/geom.py
@@ -2,7 +2,8 @@
 #
 # Copyright (c) 2012-2013 Paul Norman
 # <penorman@mac.com>
-# Released under the MIT license: http://opensource.org/licenses/mit-license.php
+# Released under the MIT license, as given in the file LICENSE, which must
+# accompany any distribution of this code.
 
 # Classes
 class Geometry(object):

--- a/ogr2osm.py
+++ b/ogr2osm.py
@@ -26,7 +26,8 @@ For additional usage information, run ogr2osm.py --help
 Copyright (c) 2012-2013 Paul Norman <penorman@mac.com>, Sebastiaan Couwenberg 
 <sebastic@xs4all.nl>, The University of Vermont <andrew.guertin@uvm.edu>
 
-Released under the MIT license: http://opensource.org/licenses/mit-license.php
+Released under the MIT license, as given in the file LICENSE, which must
+accompany any distribution of this code.
 
 Based very heavily on code released under the following terms:
 


### PR DESCRIPTION
As far as I can discern Paul's intent is that all of this code is licensed as MIT, but that license requires a copy of the license text to be provided with the source. Attribution copied from ogr2osm.py, and files that mention the license adjusted to refer to the LICENSE file rather than an online copy.
