### PR TITLE
Support PostgreSQL connections for source data

### DIFF
--- a/testfiles/basic.t
+++ b/testfiles/basic.t
@@ -8,6 +8,9 @@ usage:
   running with lxml.etree
   Usage: ogr2osm.py SRCFILE
   
+  SRCFILE can be a file path or a org PostgreSQL connection string such as:
+  "PG:dbname=pdx_bldgs user=emma host=localhost" (including the quotes)
+  
   Options:
     -h, --help            show this help message and exit
     -t TRANSLATION, --translation=TRANSLATION
@@ -38,12 +41,13 @@ usage:
                           Defaults to 0.
     --idfile=IDFILE       Read ID to start counting from from a file.
     --saveid=SAVEID       Save last ID after execution to a file.
+    --sql=SQLQUERY        SQL query to execute on a PostgreSQL source
 						  
 test1:
   $ rm -f test1.osm
   $ ogr2osm $TESTDIR/shapefiles/test1.shp
   running with lxml.etree
-  Preparing to convert file .* (re)
+  Preparing to convert .* (re)
   Will try to detect projection from source metadata, or fall back to EPSG:4326
   Using default translations
   Using default filterLayer
@@ -78,13 +82,17 @@ duplicatefile:
   running with lxml.etree
   Usage: ogr2osm.py SRCFILE
   
+  SRCFILE can be a file path or a org PostgreSQL connection string such as:
+  "PG:dbname=pdx_bldgs user=emma host=localhost" (including the quotes)
+  
   ogr2osm.py: error: ERROR: output file .*test1.osm' exists (re)
   [2]
+
 
 force:
   $ ogr2osm -f $TESTDIR/shapefiles/test1.shp
   running with lxml.etree
-  Preparing to convert file .* (re)
+  Preparing to convert .* (re)
   Will try to detect projection from source metadata, or fall back to EPSG:4326
   Using default translations
   Using default filterLayer
@@ -117,7 +125,7 @@ force:
 nomemorycopy:
   $ ogr2osm -f --no-memory-copy $TESTDIR/shapefiles/test1.shp
   running with lxml.etree
-  Preparing to convert file .* (re)
+  Preparing to convert .* (re)
   Will try to detect projection from source metadata, or fall back to EPSG:4326
   Using default translations
   Using default filterLayer
@@ -150,7 +158,7 @@ nomemorycopy:
 positiveid:
   $ ogr2osm -f --positive-id $TESTDIR/shapefiles/test1.shp
   running with lxml.etree
-  Preparing to convert file .* (re)
+  Preparing to convert .* (re)
   Will try to detect projection from source metadata, or fall back to EPSG:4326
   Using default translations
   Using default filterLayer
@@ -183,7 +191,7 @@ positiveid:
 version:
   $ ogr2osm -f --add-version $TESTDIR/shapefiles/test1.shp
   running with lxml.etree
-  Preparing to convert file .* (re)
+  Preparing to convert .* (re)
   Will try to detect projection from source metadata, or fall back to EPSG:4326
   Using default translations
   Using default filterLayer
@@ -216,7 +224,7 @@ version:
 timestamp:
   $ ogr2osm -f --add-timestamp $TESTDIR/shapefiles/test1.shp
   running with lxml.etree
-  Preparing to convert file .* (re)
+  Preparing to convert .* (re)
   Will try to detect projection from source metadata, or fall back to EPSG:4326
   Using default translations
   Using default filterLayer
@@ -248,7 +256,7 @@ timestamp:
 utf8:
   $ ogr2osm -f $TESTDIR/shapefiles/sp_usinas.shp
   running with lxml.etree
-  Preparing to convert file .* (re)
+  Preparing to convert .* (re)
   Will try to detect projection from source metadata, or fall back to EPSG:4326
   Using default translations
   Using default filterLayer
@@ -273,7 +281,7 @@ utf8:
 japanese:
   $ ogr2osm --encoding shift_jis -f $TESTDIR/shapefiles/japanese.shp
   running with lxml.etree
-  Preparing to convert file .* (re)
+  Preparing to convert .* (re)
   Will try to detect projection from source metadata, or fall back to EPSG:4326
   Using default translations
   Using default filterLayer
@@ -293,7 +301,7 @@ japanese:
 duplicatewaynodes:
   $ ogr2osm -f $TESTDIR/duplicate-way-nodes.gml
   running with lxml.etree
-  Preparing to convert file .* (re)
+  Preparing to convert .* (re)
   Will try to detect projection from source metadata, or fall back to EPSG:4326
   Using default translations
   Using default filterLayer

--- a/testfiles/basic.t
+++ b/testfiles/basic.t
@@ -369,3 +369,27 @@ duplicatewaynodes:
   Merging duplicate points in ways
   Outputting XML
   $ xmllint --format duplicate-way-nodes.osm | diff -uNr - $TESTDIR/duplicate-way-nodes.xml
+
+require_output_file_when_using_db_source:
+
+  $ ogr2osm "PG:dbname=test"
+  running with lxml.etree
+  Usage: ogr2osm.py SRCFILE
+  
+  SRCFILE can be a file path or a org PostgreSQL connection string such as:
+  "PG:dbname=pdx_bldgs user=emma host=localhost" (including the quotes)
+  
+  ogr2osm.py: error: ERROR: An output file must be explicitly specified when using a database source
+  [2]
+
+require_db_source_for_sql_query:
+
+  $ ogr2osm $TESTDIR/shapefiles/test1.shp --sql="SELECT * FROM wombats"
+  running with lxml.etree
+  Usage: ogr2osm.py SRCFILE
+  
+  SRCFILE can be a file path or a org PostgreSQL connection string such as:
+  "PG:dbname=pdx_bldgs user=emma host=localhost" (including the quotes)
+  
+  ogr2osm.py: error: ERROR: You must use a database source when specifying a query with --sql
+  [2]


### PR DESCRIPTION
This allows for an OGR-compatible PostgreSQL connection string, such as
"PG:dbname=pdx_bldgs user=emma host=localhost" to be given in place of a
source file path.

It also adds a --sql option to query the data prior to export. This is
particularly useful for exporting a single table from a complex database,
via something like “SELECT * FROM buildings”

Closes #20