### PR TITLE
Add arguments for JOSM's upload=never, download=never, and locked=true options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,5 +77,12 @@ Usage
 	  --no-memory-copy      Do not make an in-memory working copy
 	  --no-upload-false     Omit upload=false from the completed file to surpress
 							JOSM warnings when uploading.
+  	  --no-download         Prevent JOSM from downloading more data to this file.
+      --never-upload        Completely disables all upload commands for this file
+                            in JOSM, rather than merely showing a warning before
+                            uploading.
+      --locked              Prevent any changes to this file in JOSM, such as
+                            editing or downloading, and also prevents uploads.
+                            Implies upload="never" and download="never".
 	  --id=ID               ID to start counting from for the output file.
 							Defaults to 0.

--- a/README.md
+++ b/README.md
@@ -7,43 +7,43 @@ A tool for converting ogr-readable files like shapefiles into .osm data
 Installation
 ------------
 
-ogr2osm requires gdal with python bindings. Depending on the file formats 
-you want to read you may have to compile it yourself but there should be no 
+ogr2osm requires gdal with python bindings. Depending on the file formats
+you want to read you may have to compile it yourself but there should be no
 issues with shapefiles. On Ubuntu you can run `sudo apt-get install -y python-gdal python-lxml` to get
 the software you need.
 
 It also makes use of lxml. Although it should fall back to builtin XML implementations seamlessly these are less likely to be tested and will most likely run much slower.
 
-To install ogr2osm and download the default translations the following command 
+To install ogr2osm and download the default translations the following command
 can be used:
 
 	git clone --recursive https://github.com/pnorman/ogr2osm
-	
+
 To update
 
 	cd ogr2osm
 	git pull
 	git submodule update
-	
+
 About
 -----
 
-This version of ogr2osm is based on 
+This version of ogr2osm is based on
 [Andrew Guertin's version for UVM](https://github.com/andrewguertin/ogr2osm)
 which is in turn based on Ivan Ortega's version from the OSM SVN server.
 
-ogr2osm will read any data source that ogr can read and handle reprojection for 
-you. It takes a python file to translate external data source tags into OSM 
-tags, allowing you to use complicated logic. If no translation is specified it 
-will use an identity translation, carrying all tags from the source to the .osm 
-output. 
+ogr2osm will read any data source that ogr can read and handle reprojection for
+you. It takes a python file to translate external data source tags into OSM
+tags, allowing you to use complicated logic. If no translation is specified it
+will use an identity translation, carrying all tags from the source to the .osm
+output.
 
 Import Cautions
 ---------------
-Anyone planning an import into OpenStreetMap should read and review the import 
-guidelines located [on the wiki](http://wiki.openstreetmap.org/wiki/Import/Guidelines). 
-When writing your translation file you should look at other examples and 
-carefully consider each external data source tag to see if it should be 
+Anyone planning an import into OpenStreetMap should read and review the import
+guidelines located [on the wiki](http://wiki.openstreetmap.org/wiki/Import/Guidelines).
+When writing your translation file you should look at other examples and
+carefully consider each external data source tag to see if it should be
 converted to an OSM tag.
 
 Usage
@@ -65,7 +65,7 @@ Usage
 	  -p PROJ4_STRING, --proj4=PROJ4_STRING
 							PROJ.4 string. If specified, overrides projection from
 							source metadata if it exists.
-	  -v, --verbose         
+	  -v, --verbose
 	  -d, --debug-tags      Output the tags for every feature parsed.
 	  -f, --force           Force overwrite of output file.
 	  --encoding=ENCODING   Encoding of the source file. If specified, overrides
@@ -77,7 +77,7 @@ Usage
 	  --no-memory-copy      Do not make an in-memory working copy
 	  --no-upload-false     Omit upload=false from the completed file to surpress
 							JOSM warnings when uploading.
-  	  --no-download         Prevent JOSM from downloading more data to this file.
+  	  --never-download         Prevent JOSM from downloading more data to this file.
       --never-upload        Completely disables all upload commands for this file
                             in JOSM, rather than merely showing a warning before
                             uploading.

--- a/README.md
+++ b/README.md
@@ -7,43 +7,43 @@ A tool for converting ogr-readable files like shapefiles into .osm data
 Installation
 ------------
 
-ogr2osm requires gdal with python bindings. Depending on the file formats
-you want to read you may have to compile it yourself but there should be no
+ogr2osm requires gdal with python bindings. Depending on the file formats 
+you want to read you may have to compile it yourself but there should be no 
 issues with shapefiles. On Ubuntu you can run `sudo apt-get install -y python-gdal python-lxml` to get
 the software you need.
 
 It also makes use of lxml. Although it should fall back to builtin XML implementations seamlessly these are less likely to be tested and will most likely run much slower.
 
-To install ogr2osm and download the default translations the following command
+To install ogr2osm and download the default translations the following command 
 can be used:
 
 	git clone --recursive https://github.com/pnorman/ogr2osm
-
+	
 To update
 
 	cd ogr2osm
 	git pull
 	git submodule update
-
+	
 About
 -----
 
-This version of ogr2osm is based on
+This version of ogr2osm is based on 
 [Andrew Guertin's version for UVM](https://github.com/andrewguertin/ogr2osm)
 which is in turn based on Ivan Ortega's version from the OSM SVN server.
 
-ogr2osm will read any data source that ogr can read and handle reprojection for
-you. It takes a python file to translate external data source tags into OSM
-tags, allowing you to use complicated logic. If no translation is specified it
-will use an identity translation, carrying all tags from the source to the .osm
-output.
+ogr2osm will read any data source that ogr can read and handle reprojection for 
+you. It takes a python file to translate external data source tags into OSM 
+tags, allowing you to use complicated logic. If no translation is specified it 
+will use an identity translation, carrying all tags from the source to the .osm 
+output. 
 
 Import Cautions
 ---------------
-Anyone planning an import into OpenStreetMap should read and review the import
-guidelines located [on the wiki](http://wiki.openstreetmap.org/wiki/Import/Guidelines).
-When writing your translation file you should look at other examples and
-carefully consider each external data source tag to see if it should be
+Anyone planning an import into OpenStreetMap should read and review the import 
+guidelines located [on the wiki](http://wiki.openstreetmap.org/wiki/Import/Guidelines). 
+When writing your translation file you should look at other examples and 
+carefully consider each external data source tag to see if it should be 
 converted to an OSM tag.
 
 Usage
@@ -65,7 +65,7 @@ Usage
 	  -p PROJ4_STRING, --proj4=PROJ4_STRING
 							PROJ.4 string. If specified, overrides projection from
 							source metadata if it exists.
-	  -v, --verbose
+	  -v, --verbose         
 	  -d, --debug-tags      Output the tags for every feature parsed.
 	  -f, --force           Force overwrite of output file.
 	  --encoding=ENCODING   Encoding of the source file. If specified, overrides
@@ -77,12 +77,12 @@ Usage
 	  --no-memory-copy      Do not make an in-memory working copy
 	  --no-upload-false     Omit upload=false from the completed file to surpress
 							JOSM warnings when uploading.
-  	  --never-download         Prevent JOSM from downloading more data to this file.
-      --never-upload        Completely disables all upload commands for this file
-                            in JOSM, rather than merely showing a warning before
-                            uploading.
-      --locked              Prevent any changes to this file in JOSM, such as
-                            editing or downloading, and also prevents uploads.
-                            Implies upload="never" and download="never".
+	  --never-download      Prevent JOSM from downloading more data to this file.
+	  --never-upload        Completely disables all upload commands for this file
+							in JOSM, rather than merely showing a warning before
+							uploading.
+	  --locked              Prevent any changes to this file in JOSM, such as
+							editing or downloading, and also prevents uploads.
+							Implies upload="never" and download="never".
 	  --id=ID               ID to start counting from for the output file.
 							Defaults to 0.

--- a/ogr2osm.py
+++ b/ogr2osm.py
@@ -486,7 +486,7 @@ def output():
         elif not OPTIONS.noUploadFalse:
             dec_string += ' upload="false'
             # f.write('<?xml version="1.0"?>\n<osm version="0.6" generator="uvmogr2osm">\n')
-        if OPTIONS.noDownload:
+        if OPTIONS.neverDownload:
             dec_string += ' download="never"'
             # f.write('<?xml version="1.0"?>\n<osm version="0.6" upload="never" download="never" generator="uvmogr2osm">\n')
         if OPTIONS.locked:
@@ -611,7 +611,7 @@ def main():
     parser.add_option("--no-upload-false", dest="noUploadFalse", action="store_true",
                         help="Omit upload=false from the completed file to surpress JOSM warnings when uploading.")
 
-    parser.add_option("--no-download", dest="noDownload", action="store_true",
+    parser.add_option("--never-download", dest="neverDownload", action="store_true",
                       help="Prevent JOSM from downloading more data to this file.")
 
     parser.add_option("--never-upload", dest="neverUpload", action="store_true",
@@ -655,7 +655,7 @@ def main():
                         debugTags=False,
                         translationMethod=None, outputFile=None,
                         forceOverwrite=False, noUploadFalse=False,
-                        noDownload=False, neverUpload=False,
+                        neverDownload=False, neverUpload=False,
                         locked=False)
 
     # Parse and process arguments

--- a/ogr2osm.py
+++ b/ogr2osm.py
@@ -484,11 +484,9 @@ def output():
         if OPTIONS.neverUpload:
             dec_string += ' upload="never"'
         elif not OPTIONS.noUploadFalse:
-            dec_string += ' upload="false'
-            # f.write('<?xml version="1.0"?>\n<osm version="0.6" generator="uvmogr2osm">\n')
+            dec_string += ' upload="false"'
         if OPTIONS.neverDownload:
             dec_string += ' download="never"'
-            # f.write('<?xml version="1.0"?>\n<osm version="0.6" upload="never" download="never" generator="uvmogr2osm">\n')
         if OPTIONS.locked:
             dec_string += ' locked="true"'
         dec_string += '>\n'

--- a/ogr2osm.py
+++ b/ogr2osm.py
@@ -483,7 +483,7 @@ def output():
         if OPTIONS.noUploadFalse:
             f.write('<?xml version="1.0"?>\n<osm version="0.6" generator="uvmogr2osm">\n')
         else:
-            f.write('<?xml version="1.0"?>\n<osm version="0.6" upload="false" generator="uvmogr2osm">\n')
+            f.write('<?xml version="1.0"?>\n<osm version="0.6" upload="never" download="never" generator="uvmogr2osm">\n')
 
         # Build up a dict for optional settings
         attributes = {}

--- a/ogr2osm.py
+++ b/ogr2osm.py
@@ -480,10 +480,19 @@ def output():
     # Open up the output file with the system default buffering
     with open(OPTIONS.outputFile, 'w', buffering=-1) as f:
 
-        if OPTIONS.noUploadFalse:
-            f.write('<?xml version="1.0"?>\n<osm version="0.6" generator="uvmogr2osm">\n')
-        else:
-            f.write('<?xml version="1.0"?>\n<osm version="0.6" upload="never" download="never" generator="uvmogr2osm">\n')
+        dec_string = '<?xml version="1.0"?>\n<osm version="0.6" generator="uvmogr2osm"'
+        if OPTIONS.neverUpload:
+            dec_string += ' upload="never"'
+        elif not OPTIONS.noUploadFalse:
+            dec_string += ' upload="false'
+            # f.write('<?xml version="1.0"?>\n<osm version="0.6" generator="uvmogr2osm">\n')
+        if OPTIONS.noDownload:
+            dec_string += ' download="never"'
+            # f.write('<?xml version="1.0"?>\n<osm version="0.6" upload="never" download="never" generator="uvmogr2osm">\n')
+        if OPTIONS.locked:
+            dec_string += ' locked="true"'
+        dec_string += '>\n'
+        f.write(dec_string)
 
         # Build up a dict for optional settings
         attributes = {}
@@ -602,6 +611,18 @@ def main():
     parser.add_option("--no-upload-false", dest="noUploadFalse", action="store_true",
                         help="Omit upload=false from the completed file to surpress JOSM warnings when uploading.")
 
+    parser.add_option("--no-download", dest="noDownload", action="store_true",
+                      help="Prevent JOSM from downloading more data to this file.")
+
+    parser.add_option("--never-upload", dest="neverUpload", action="store_true",
+                      help="Completely disables all upload commands for this file in JOSM, " +
+                      "rather than merely showing a warning before uploading.")
+
+    parser.add_option("--locked", dest="locked", action="store_true",
+                      help="Prevent any changes to this file in JOSM, " +
+                      "such as editing or downloading, and also prevents uploads. " +
+                      "Implies upload=\"never\" and download=\"never\".")
+
     parser.add_option("--id", dest="id", type=int, default=0,
                         help="ID to start counting from for the output file. Defaults to 0.")
 
@@ -633,7 +654,9 @@ def main():
     parser.set_defaults(sourceEPSG=None, sourcePROJ4=None, verbose=False,
                         debugTags=False,
                         translationMethod=None, outputFile=None,
-                        forceOverwrite=False, noUploadFalse=False)
+                        forceOverwrite=False, noUploadFalse=False,
+                        noDownload=False, neverUpload=False,
+                        locked=False)
 
     # Parse and process arguments
     (OPTIONS, args) = parser.parse_args()


### PR DESCRIPTION
OSM files used in JOSM can have flags to [never upload](https://josm.openstreetmap.de/wiki/Help/Action/EncourageDiscourageUpload) (completely disables the option to upload the layer, contrasted with `upload=false` which displays a warning but allows the user to click through and upload anyway); [never download](https://josm.openstreetmap.de/wiki/Help/Action/BlockDownload) (prevents user from downloading additional data into the layer); or be [locked](https://josm.openstreetmap.de/wiki/Help/Action/LockedLayer), which is the previous two options and additionally prevents any modification of features in the layer at all.

This PR adds arguments to use any of these options in the output .osm file. In order to do this, I rewrote the function that writes the osm tag from an `if...else` statement to an `if...elif...if...if` statement, constructing the tag string over several lines of code so that the different permutations are covered.