### PR TITLE
Fix axis swapping with GDAL 3.0

### DIFF
--- a/ogr2osm.py
+++ b/ogr2osm.py
@@ -185,6 +185,10 @@ def getTransform(layer):
         reproject = lambda geometry: None
     else:
         destSpatialRef = osr.SpatialReference()
+        try:
+            destSpatialRef.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        except AttributeError:
+            pass
         # Destionation projection will *always* be EPSG:4326, WGS84 lat-lon
         destSpatialRef.ImportFromEPSG(4326)
         coordTrans = osr.CoordinateTransformation(spatialRef, destSpatialRef)


### PR DESCRIPTION
In GDAL 3.0, [spatial reference handling was rewritten to handle axis ordering more properly](https://trac.osgeo.org/gdal/wiki/rfc73_proj6_wkt2_srsbarn#Axisorderissues). Unfortunately, that's sometimes the other way around from what existing software expects, leading to, in this case, latitude and longitude being swapped in exports from ogr2osm. Luckily, they supplied a function to revert to the old behavior. This patch calls that function if it's available, so that GDAL 2.x also still works fine.